### PR TITLE
Support records endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ const { Search } = require('sumologic-client');
     to: '2019-06-25T17:14:31+09:00'
   };
 
-  const it = await client.getIterator(searchParams);
+  const it = await client.getMessageIterator(searchParams);
 
   for await (let response of it) {
       // check the latest backend state and total
       // number of results gathered so far:
       console.log(response.state);
 
-      // new search results since the last iteration: 
+      // new search results since the last iteration:
       console.log(response.results);
   }
 })();

--- a/test/fixtures/02.js
+++ b/test/fixtures/02.js
@@ -1,0 +1,199 @@
+module.exports = [{
+  scope: 'https://api.jp.sumologic.com:443',
+  method: 'POST',
+  path: '/api/v1/search/jobs',
+  body: {
+    query: 'sample_query',
+    from: '2019-06-25T10:14:31+09:00',
+    to: '2019-06-25T17:14:31+09:00',
+    timeZone: 'Asia/Tokyo'
+  },
+  status: 202,
+  response: {
+    id: '750D3ABE4460BA73',
+    link: {
+      rel: 'self',
+      href: 'https://api.jp.sumologic.com/api/v1/search/jobs/750D3ABE4460BA73'
+    }
+  },
+  rawHeaders: [
+    'Date',
+    'Wed, 10 Jul 2019 04:10:36 GMT',
+    'Content-Type',
+    'application/json',
+    'Transfer-Encoding',
+    'chunked',
+    'Connection',
+    'close',
+    'Set-Cookie',
+    'AWSALB=Pxmydyk+9LMvAEfZH2h55jJve2ufmwdneWqzPcrul85wJo8SD0DoFmSBQIDhde3Sv1rp4Z/D3JXi7l0MLGtr0e1IhE6XhN8ihEAQoMPtEcPrJCRi7EYX0AJCS/03; Expires=Wed, 17 Jul 2019 04:10:36 GMT; Path=/',
+    'Cache-Control',
+    'no-cache, no-store, max-age=0, must-revalidate',
+    'Pragma',
+    'no-cache',
+    'Expires',
+    'Thu, 01 Jan 1970 00:00:00 GMT',
+    'X-XSS-Protection',
+    '1; mode=block',
+    'X-Frame-Options',
+    'DENY',
+    'X-Content-Type-Options',
+    'nosniff',
+    'Set-Cookie',
+    'JSESSIONID=node0z8u0k92qywg3ek8wy6br6dj2843.node0; Path=/api',
+    'Location',
+    'https://api.jp.sumologic.com/api/v1/search/jobs/750D3ABE4460BA73'
+  ]
+},
+{
+  scope: 'https://api.jp.sumologic.com:443',
+  method: 'GET',
+  path: '/api/v1/search/jobs/750D3ABE4460BA73',
+  body: '',
+  status: 200,
+  response: {
+    state: 'DONE GATHERING RESULTS',
+    histogramBuckets: [
+      {
+        startTimestamp: 1561425300000,
+        length: 300000,
+        count: 576
+      },
+      {
+        startTimestamp: 1561425271000,
+        length: 29000,
+        count: 78
+      }
+    ],
+    messageCount: 3,
+    recordCount: 0,
+    pendingWarnings: [],
+    pendingErrors: []
+  },
+  rawHeaders: [
+    'Date',
+    'Wed, 10 Jul 2019 04:10:36 GMT',
+    'Content-Type',
+    'application/json;charset=utf-8',
+    'Transfer-Encoding',
+    'chunked',
+    'Connection',
+    'close',
+    'Set-Cookie',
+    'AWSALB=G6vGpwo8A/C1Zu+1IpQU3WVBpYJqr+JToBZ0+s8l3EPYaePY5gVHxz8IJUTa1Mf/YdJnS09GFLakCjPP3v4z5CAqyObDcQTWUb+UI8ddmyxFEuSt+C7A8xApOZlm; Expires=Wed, 17 Jul 2019 04:10:36 GMT; Path=/',
+    'Cache-Control',
+    'no-cache, no-store, max-age=0, must-revalidate',
+    'Pragma',
+    'no-cache',
+    'Expires',
+    'Thu, 01 Jan 1970 00:00:00 GMT',
+    'X-XSS-Protection',
+    '1; mode=block',
+    'X-Frame-Options',
+    'DENY',
+    'X-Content-Type-Options',
+    'nosniff',
+    'Set-Cookie',
+    'JSESSIONID=node0shrdo704xzmy1sgazlho1l8z42840.node0; Path=/api',
+    'Vary',
+    'Accept-Encoding, User-Agent'
+  ]
+}, {
+  scope: 'https://api.jp.sumologic.com:443',
+  method: 'GET',
+  path: '/api/v1/search/jobs/750D3ABE4460BA73/records?offset=0&limit=50000',
+  body: '',
+  status: 200,
+  response: {
+    fields: [
+      {
+        name: 'sample-field',
+        fieldType: 'long',
+        keyField: false
+      }
+    ],
+    records: [
+      {
+        "map": {
+          "_count": "1",
+          "key": "aggregation key1",
+        }
+      },
+      {
+        "map": {
+          "_count": "2",
+          "key": "aggregation key2",
+        }
+      },
+      {
+        "map": {
+          "_count": "3",
+          "key": "aggregation key3",
+        }
+      }
+    ]
+  },
+  rawHeaders: [
+    'Date',
+    'Wed, 10 Jul 2019 04:10:36 GMT',
+    'Content-Type',
+    'application/json;charset=utf-8',
+    'Transfer-Encoding',
+    'chunked',
+    'Connection',
+    'close',
+    'Set-Cookie',
+    'AWSALB=TwtM7wDsw4K/kc52LbyjxJZNENNUeDU/t0/9NVDxUU/0EqLuCyor/Ym9eevsol1hl8BTFVnuVEIGxdkgM0mqzDEUHARpwhHjl8axm8NKxpJFYV+BMU9lyuLbMdXo; Expires=Wed, 17 Jul 2019 04:10:36 GMT; Path=/',
+    'Cache-Control',
+    'no-cache, no-store, max-age=0, must-revalidate',
+    'Pragma',
+    'no-cache',
+    'Expires',
+    'Thu, 01 Jan 1970 00:00:00 GMT',
+    'X-XSS-Protection',
+    '1; mode=block',
+    'X-Frame-Options',
+    'DENY',
+    'X-Content-Type-Options',
+    'nosniff',
+    'Set-Cookie',
+    'JSESSIONID=node013d6vnkzzyjexr2dcnemtws1d2841.node0; Path=/api',
+    'Vary',
+    'Accept-Encoding, User-Agent'
+  ]
+}, {
+  scope: 'https://api.jp.sumologic.com:443',
+  method: 'DELETE',
+  path: '/api/v1/search/jobs/750D3ABE4460BA73',
+  body: '',
+  status: 200,
+  response: {
+    id: '750D3ABE4460BA73'
+  },
+  rawHeaders: [
+    'Date',
+    'Wed, 10 Jul 2019 04:10:37 GMT',
+    'Content-Type',
+    'application/json;charset=utf-8',
+    'Transfer-Encoding',
+    'chunked',
+    'Connection',
+    'close',
+    'Set-Cookie',
+    'AWSALB=lmcUMXglhcyc2AeVaWGWPZB9eWMxQ8VEJHBgZlUuqa37n5yLlvp01+7LL2Z8ghzQkm7CxmBlzW3u+Anhi5HwJIuMeJ/hDQFpM5Xw2dJNynVWe8sR0xO4QuR5yU4B; Expires=Wed, 17 Jul 2019 04:10:37 GMT; Path=/',
+    'Cache-Control',
+    'no-cache, no-store, max-age=0, must-revalidate',
+    'Pragma',
+    'no-cache',
+    'Expires',
+    'Thu, 01 Jan 1970 00:00:00 GMT',
+    'X-XSS-Protection',
+    '1; mode=block',
+    'X-Frame-Options',
+    'DENY',
+    'X-Content-Type-Options',
+    'nosniff',
+    'Set-Cookie',
+    'JSESSIONID=node0mkt2s73n3p8umrb4rofhd25a2842.node0; Path=/api'
+  ]
+}];

--- a/test/fixtures/02.js
+++ b/test/fixtures/02.js
@@ -66,7 +66,7 @@ module.exports = [{
       }
     ],
     messageCount: 3,
-    recordCount: 0,
+    recordCount: 3,
     pendingWarnings: [],
     pendingErrors: []
   },

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -138,7 +138,7 @@ describe('search()', () => {
     nock.restore();
   });
 
-  test('it works correctly', async () => {
+  test('it works to get messages correctly', async () => {
     // TODO
     // is there anything better than this?
     const requests = require('./fixtures/00.js');
@@ -157,7 +157,7 @@ describe('search()', () => {
       from: '2019-06-25T10:14:31+09:00',
       to: '2019-06-25T17:14:31+09:00'
     };
-    const iterator = await client.getIterator(searchParams);
+    const iterator = await client.getMessageIterator(searchParams);
     for await (const response of iterator) {
       expect(response.state).toEqual({
         state: 'DONE GATHERING RESULTS',
@@ -225,7 +225,7 @@ describe('search()', () => {
       to: '2019-06-25T17:14:31+09:00',
       byReceiptTime: true
     };
-    const iterator = await client.getIterator(searchParams);
+    const iterator = await client.getMessageIterator(searchParams);
     for await (const response of iterator) {
       expect(response.state).toEqual({
         state: 'DONE GATHERING RESULTS',
@@ -268,6 +268,78 @@ describe('search()', () => {
           {
             map: {
               msg: 'message3'
+            }
+          }
+        ]
+      });
+    }
+  });
+
+  test('it works to get records correctly', async () => {
+    // TODO
+    // is there anything better than this?
+    const requests = require('./fixtures/02.js');
+    requests.forEach((req) => {
+      const urlAndBody = [req.path];
+      if (req.method === 'POST') {
+        urlAndBody.push(JSON.stringify(req.body));
+      }
+      nock('https://api.jp.sumologic.com/')[req.method.toLowerCase()](...urlAndBody)
+        .reply(...[req.status, req.response]);
+    });
+
+    const client = createClient({ pollingDelay: 1 });
+    const searchParams = {
+      query: 'sample_query',
+      from: '2019-06-25T10:14:31+09:00',
+      to: '2019-06-25T17:14:31+09:00'
+    };
+    const iterator = await client.getMessageIterator(searchParams);
+    for await (const response of iterator) {
+      expect(response.state).toEqual({
+        state: 'DONE GATHERING RESULTS',
+        histogramBuckets: [
+          {
+            startTimestamp: 1561425300000,
+            length: 300000,
+            count: 576
+          },
+          {
+            startTimestamp: 1561425271000,
+            length: 29000,
+            count: 78
+          }
+        ],
+        messageCount: 3,
+        recordCount: 0,
+        pendingWarnings: [],
+        pendingErrors: []
+      });
+      expect(response.results).toEqual({
+        fields: [
+          {
+            name: 'sample-field',
+            fieldType: 'long',
+            keyField: false
+          }
+        ],
+        records: [
+          {
+            "map": {
+              "_count": "1",
+              "key": "aggregation key1",
+            }
+          },
+          {
+            "map": {
+              "_count": "2",
+              "key": "aggregation key2",
+            }
+          },
+          {
+            "map": {
+              "_count": "3",
+              "key": "aggregation key3",
             }
           }
         ]

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -294,7 +294,7 @@ describe('search()', () => {
       from: '2019-06-25T10:14:31+09:00',
       to: '2019-06-25T17:14:31+09:00'
     };
-    const iterator = await client.getMessageIterator(searchParams);
+    const iterator = await client.getRecordIterator(searchParams);
     for await (const response of iterator) {
       expect(response.state).toEqual({
         state: 'DONE GATHERING RESULTS',
@@ -311,7 +311,7 @@ describe('search()', () => {
           }
         ],
         messageCount: 3,
-        recordCount: 0,
+        recordCount: 3,
         pendingWarnings: [],
         pendingErrors: []
       });


### PR DESCRIPTION
### Summary

Sumo Logic Search Job API has an endpoint for getting aggregation results.

https://help.sumologic.com/APIs/Search-Job-API/About-the-Search-Job-API#paging-through-the-records-found-by-a-search-job

Sample endpoint response

```json
{
  "fields": [
    {
      "name": "jobfid",
      "fieldType": "string",
      "keyField": true
    },
    {
      "name": "jobstatus",
      "fieldType": "string",
      "keyField": true
    },
    {
      "name": "_count",
      "fieldType": "int",
      "keyField": false
    }
  ],
  "records": [
    {
      "map": {
        "_count": "3",
        "jobstatus": "error",
        "jobfid": "somejobid"
      }
    },
    {
      "map": {
        "_count": "10",
        "jobstatus": "error",
        "jobfid": "anotherjobid"
      }
    }
  ]
}
```

You can check a real response by modifying sample bash script.

ref: https://help.sumologic.com/APIs/Search-Job-API/About-the-Search-Job-API#bash-this-search-job

<details>
<summary>bash script(set your access key and access id)</summary>

```bash
#!/bin/bash

#https://help.sumologic.com/APIs/Search-Job-API/About-the-Search-Job-API
# Variables.
PROTOCOL="https"    # HTTPS is the only acceptable PROTOCOL
HOST="api.jp.sumologic.com"        # Use your Sumo endpoint as the HOST
ACCESSID="YOURACCESSID"     # Authenticate with an access id and key
ACCESSKEY="YOURACCESSKEY"
OPTIONS="--silent -b cookies.txt -c cookies.txt"
#OPTIONS="-v -b cookies.txt -c cookies.txt"
#OPTIONS="-v --trace-ascii -b cookies.txt -c cookies.txt"

#
# Create a search job from a JSON file.
#
RESULT=$(curl $OPTIONS                                                                \
          -H "Content-type: application/json"                                         \
          -H "Accept: application/json"                                               \
          -d @createSearchJob.json                                                    \
          --user $ACCESSID:$ACCESSKEY                                                     \
          "$PROTOCOL://$HOST/api/v1/search/jobs")
JOB_ID=$(echo $RESULT | perl -pe 's|.*"id":"(.*?)"[,}].*|\1|')
echo Search job created, id: $JOB_ID

#
# Wait until the search job is done.
#
STATE=""
until [ "$STATE" = "DONE GATHERING RESULTS" ]; do
  sleep 5
  RESULT=$(curl $OPTIONS                                                              \
            -H "Accept: application/json"                                             \
            --user $ACCESSID:$ACCESSKEY                                                   \
            "$PROTOCOL://$HOST/api/v1/search/jobs/$JOB_ID")
  STATE=$(echo $RESULT | sed 's/.*"state":"\(.*\)"[,}].*/\1/')
  MESSAGES=$(echo $RESULT | perl -pe 's|.*"messageCount":(.*?)[,}].*|\1|')
  RECORDS=$(echo $RESULT | perl -pe 's|.*"recordCount":(.*?)[,}].*|\1|')
  echo $RESULT
  # echo Search job state: $STATE, message count: $MESSAGES, record count: $RECORDS
done

#
# Get the first ten messages.
#
RESULT=$(curl $OPTIONS                                                                \
          -H "Accept: application/json"                                               \
          --user $ACCESSID:$ACCESSKEY                                                      \
          "$PROTOCOL://$HOST/api/v1/search/jobs/$JOB_ID/records?offset=0&limit=10")
echo Records:
echo $RESULT

#
# Delete the search job.
#
RESULT=$(curl $OPTIONS                                                                \
          -X DELETE                                                                   \
          -H "Accept: application/json"                                               \
          --user $ACCESSID:$ACCESSKEY                                                      \
          "$PROTOCOL://$HOST/api/v1/search/jobs/$JOB_ID")
JOB_ID=$(echo $RESULT | sed 's/^.*"id":"\(.*\)".*$/\1/')
echo Search job deleted, id: $JOB_ID
```
</details>

sample createSearchJob.json

```json
{
  "query": "_sourceCategory=mt/aws/jp/production/* \"scrape task\" | json auto | parse field=msg \"Scrape task *: '*' (jobid: '*', fid: '*', system: '*', credential_id: '*', region: '*', time: '*', guest_initiated: *)\" as result,jobstatus,jobid,jobfid,jobsys,jobcid,jobregion,jobtime,jobguest | parse field=_source \"ssu production *\" as instanceid | count by jobfid, jobstatus",
  "from": "2019-12-12T10:59:28",
  "to": "2019-12-13T10:59:28",
  "timeZone": "JST",
  "byReceiptTime": true
}
```

### Things I fixed and Review points

Fixed: 

- Added `getMessageIterator` and `getRecordIterator` functions
- Fixed `getIterator` function to act as a private method and add `type` argument
- Fixed `getJobResults` to add `type` argument

Review points:

- Should I change `getJobResults` to act as a private method and added wrapper methods like `getMessageJobResults` and `getRecordsJobResults`? I'm not sure `getJobResults` should be public.