### PR TITLE
fix: moment.tz is not a function

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -1,6 +1,5 @@
 const axios = require('axios');
-const moment = require('moment');
-require('moment-timezone');
+const moment = require('moment-timezone');
 const debug = require('debug');
 
 const log = debug('sumologic-search');


### PR DESCRIPTION
This library uses moment-timezone and the requirement is wrong.

ref:
- https://momentjs.com/timezone/docs/
- https://stackoverflow.com/a/48724909

Currently we have the following error by this

``` json
{
    "errorMessage": "moment(...).tz is not a function",
    "errorType": "TypeError",
    "stackTrace": [
        "TypeError: moment(...).tz is not a function",
        "    at Search.newSearchJob (/Users/yoheikoyama/ghq/github.com/mt-yohei-koyama/tidy-up/node_modules/@moneytree/sumologic-client/src/search.js:113:50)",
        "    at Search._getIterator (/Users/yoheikoyama/ghq/github.com/mt-yohei-koyama/tidy-up/node_modules/@moneytree/sumologic-client/src/search.js:180:30)",
        "    at _getIterator.next (<anonymous>)",
        "    at exports.run (/Users/yoheikoyama/ghq/github.com/mt-yohei-koyama/tidy-up/src/handler.js:48:20)"
    ]
}
```
